### PR TITLE
removing async wifi scan since it always returns empty

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Esp32WifiManager
-version=0.14.0
+version=0.15.0
 author=Kevin Harrington <mad.hephaestus@gmail.com>
 maintainer=Kevin Harrington <mad.hephaestus@gmail.com>
 sentence=This Arduino library supports Wifi Management for Esp32.

--- a/src/wifi/WifiManager.cpp
+++ b/src/wifi/WifiManager.cpp
@@ -155,7 +155,7 @@ int WifiManager::updateApList(){
 	WiFi.disconnect(true);
 	delay(100);
 	int16_t n = WiFi.scanComplete();
-	WiFi.scanNetworks(true,  false, false, 300);
+	WiFi.scanNetworks(false,  false, false, 300); //async mode will always return an empty list
 	state = scanRunning;
 	whatToDoAfterScanning= reconnect;
 	return n;


### PR DESCRIPTION
Wifi scan in async mode will always return an empty list in the newest versions of the wifi api. This change removes it and this lib now works on the newest version of the esp32 arduino packages 